### PR TITLE
fix(alerts): never write an undefined message field (InfluxDB 'invalid boolean')

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ const AlertType = {
   PLAY_FILENOTFOUND: 'play-url-notfound',
   TTS_STREAMING_CONNECTION_FAILURE: 'tts-streaming-connection-failure',
   KRISP_NOT_PROVISIONED: 'no-krisp',
-  APPLICATION: 'alert-from-application'
+  APPLICATION: 'alert-from-application',
+  ERROR_UPDATING_CALL: 'error-updating-call'
 };
 
 const schemas = {
@@ -735,11 +736,19 @@ const writeAlerts = async(client, alerts) => {
           case AlertType.TTS_STREAMING_CONNECTION_FAILURE:
             message = `Failed to connect to tts streaming service at ${vendor}`;
             break;
+          case AlertType.ERROR_UPDATING_CALL:
+            message = `error updating call${detail ? `: ${detail}` : ''}`;
+            break;
           default:
             break;
         }
       }
-      let fields =  { message };
+      /* Never write an undefined/empty (or non-string) message field. In line
+       * protocol an undefined value serializes to the bare token `undefined`,
+       * which InfluxDB rejects ("invalid boolean") and fails the entire batch
+       * write — taking down every alert in the same flush. */
+      if (!message) message = alert_type || 'unknown alert';
+      let fields =  { message: String(message) };
       if (target_sid) fields = Object.assign(fields, {target_sid});
       const obj = {measurement: 'alerts', fields: fields, tags: { alert_type, service_provider_sid, account_sid,
         ...(vendor && {vendor})}};

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -214,6 +214,41 @@ test('write timeseries data', async(t) => {
   //console.log(result);
   t.ok(result.data.length === 15, 'queried alerts by service_provider_sid');
 
+  /* regression: an alert with no resolvable message must not poison the write.
+   * Previously `message: undefined` serialized to the bare token `undefined`
+   * in line protocol and InfluxDB rejected the whole batch ("invalid boolean").
+   * Distinct account_sids (a tag) so each is its own series and a shared
+   * service_provider_sid that doesn't collide with the counts above. */
+  await writeAlerts([
+    {
+      // ERROR_UPDATING_CALL with an undefined message + detail (the prod shape)
+      alert_type: AlertType.ERROR_UPDATING_CALL,
+      service_provider_sid: 'sp-guard',
+      account_sid: 'acct-guard-1',
+      message: undefined,
+      detail: 'cannot read property foo of undefined',
+      target_sid: 'call-guard'
+    },
+    {
+      // ERROR_UPDATING_CALL with neither message nor detail (bare default)
+      alert_type: AlertType.ERROR_UPDATING_CALL,
+      service_provider_sid: 'sp-guard',
+      account_sid: 'acct-guard-2'
+    },
+    {
+      // an unknown alert_type with no message must still produce a valid write
+      alert_type: 'some-unknown-alert-type',
+      service_provider_sid: 'sp-guard',
+      account_sid: 'acct-guard-3'
+    }
+  ]);
+  t.pass('wrote alerts with undefined/missing message without poisoning the batch');
+
+  result = await queryAlertsSP({service_provider_sid: 'sp-guard', page: 1, page_size: 25, days: 7});
+  t.ok(result.data.length === 3, 'all three guard alerts were stored (write was not rejected)');
+  t.ok(result.data.every((a) => typeof a.message === 'string' && a.message.length > 0),
+    'every stored alert has a non-empty string message');
+
   result = await writeCallCount(
     {
       calls_in_progress: 49,


### PR DESCRIPTION
## The bug (seen in prod)

A feature-server box logged an InfluxDB 400 while writing a call-error alert:

```
A 400 Bad Request error occurred:
{"error":"unable to parse 'alerts,alert_type=error-updating-call,... message=undefined,target_sid=\"...\"': invalid boolean"}
```

`writeAlerts` only auto-generates a default `message` for the alert types it has a `case` for in the switch. For any **unknown `alert_type`** — or any alert whose `message` is `undefined` and isn't in the switch — execution fell through to:

```js
let fields = { message };   // message === undefined
```

The influx client serializes `{message: undefined}` to the bare token `message=undefined` in line protocol (no quotes). InfluxDB then tries to parse it — the `message` field is declared `STRING`, but an unquoted bare token gets parsed as a boolean → **`invalid boolean`**, and the 400 **rejects the entire batch flush**, dropping every alert in it.

In prod this fired because feature-server writes an `error-updating-call` alert (an `alert_type` that has never existed in this package's `AlertType` enum) with `message: err.message`, and in that path `err.message` was `undefined`.

## Fix

1. **Add `ERROR_UPDATING_CALL: 'error-updating-call'` to `AlertType`** plus a default-message `case`, so it's a first-class, queryable alert type (it'll actually show up in the portal alerts) rather than a magic string that falls through.
2. **Defensive guard** right before building `fields`:
   ```js
   if (!message) message = alert_type || 'unknown alert';
   let fields = { message: String(message) };
   ```
   This protects **every** alert path — known or unknown — from ever poisoning a write with an `undefined`/empty/non-string field. The root defect was that a single malformed field can take down a whole batch; this makes that impossible.

## Test

Added a regression in `test/unit-tests.js` (distinct `account_sid`s under a fresh `service_provider_sid`, so it doesn't disturb the existing exact-count assertions): it writes alerts with an `undefined` message, a missing message, and an **unknown `alert_type`**, then asserts the batch is accepted and every stored row has a non-empty string message.

Verified both ways against the dockerized InfluxDB:
- **With the fix reverted** → reproduces the exact prod failure: `not ok … invalid boolean` on `message=undefined` (write rejected).
- **With the fix** → **36/36 pass.**

## Follow-ups (separate, not in this PR)

- Publish a new `@jambonz/time-series` (version bump + `npm publish`) and bump feature-server's dependency.
- feature-server: reference `AlertType.ERROR_UPDATING_CALL` instead of the hardcoded string at `call-session.js`, and `.catch()` the un-awaited `writeAlerts` call (its surrounding `try/catch` can't catch the async rejection, which is why the prod failure surfaced as an "Unhandled rejection").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
